### PR TITLE
fix: handle end portal frame activations on block place

### DIFF
--- a/src/main/java/net/simplyvanilla/noillegals/check/BlockPlaceCheck.java
+++ b/src/main/java/net/simplyvanilla/noillegals/check/BlockPlaceCheck.java
@@ -10,15 +10,17 @@ import org.bukkit.event.block.BlockPlaceEvent;
 public class BlockPlaceCheck implements Listener {
     @EventHandler
     public void onBlockPlace(BlockPlaceEvent event) {
-        // We check if the placed item is a end portal, the block that was placed against is a end portal, and the item in hand is a ender eye.
-        if (event.getBlock().getType().equals(Material.END_PORTAL_FRAME) &&
-            event.getBlockAgainst().getType().equals(
-                Material.END_PORTAL_FRAME) &&
-            event.getItemInHand().getType().equals(Material.ENDER_EYE)) {
-            return;
-        }
         Bukkit.getScheduler().runTaskAsynchronously(NoIllegalsPlugin.getInstance(), () -> {
             if (NoIllegalsPlugin.checkOPPlayers && event.getPlayer().isOp()) {
+                return;
+            }
+
+            // We check if the placed item is a end portal, the block that was placed against is a end portal, and the item in hand is a ender eye.
+            if (NoIllegalsPlugin.isItemBlocked(event.getBlock().getType()) &&
+                event.getBlock().getType().equals(Material.END_PORTAL_FRAME) &&
+                event.getBlockAgainst().getType().equals(
+                    Material.END_PORTAL_FRAME) &&
+                event.getItemInHand().getType().equals(Material.ENDER_EYE)) {
                 return;
             }
 

--- a/src/main/java/net/simplyvanilla/noillegals/check/BlockPlaceCheck.java
+++ b/src/main/java/net/simplyvanilla/noillegals/check/BlockPlaceCheck.java
@@ -10,12 +10,22 @@ import org.bukkit.event.block.BlockPlaceEvent;
 public class BlockPlaceCheck implements Listener {
     @EventHandler
     public void onBlockPlace(BlockPlaceEvent event) {
+        // We check if the placed item is a end portal, the block that was placed against is a end portal, and the item in hand is a ender eye.
+        if (event.getBlock().getType().equals(Material.END_PORTAL_FRAME) &&
+            event.getBlockAgainst().getType().equals(
+                Material.END_PORTAL_FRAME) &&
+            event.getItemInHand().getType().equals(Material.ENDER_EYE)) {
+            return;
+        }
         Bukkit.getScheduler().runTaskAsynchronously(NoIllegalsPlugin.getInstance(), () -> {
-            if (NoIllegalsPlugin.checkOPPlayers && event.getPlayer().isOp())
+            if (NoIllegalsPlugin.checkOPPlayers && event.getPlayer().isOp()) {
                 return;
+            }
 
-            if (NoIllegalsPlugin.isItemBlocked(event.getBlock().getType()))
-                Bukkit.getScheduler().runTaskLater(NoIllegalsPlugin.getInstance(), () -> event.getBlock().setType(Material.AIR), 1L);
+            if (NoIllegalsPlugin.isItemBlocked(event.getBlock().getType())) {
+                Bukkit.getScheduler().runTaskLater(NoIllegalsPlugin.getInstance(),
+                    () -> event.getBlock().setType(Material.AIR), 1L);
+            }
         });
     }
 }


### PR DESCRIPTION
This is a special case where activations of end portal frames count as block placements. I added a check for this exception:

- if the block is a end portal frame
- if the block that was placed against is end portal frame
- if the player has a eye of ender in this hand

With that you can activate end portal frames, but can't place them. Also not trying to place them nearby end portal frames because the player doesn't have a eye of ender in the hand in this case, which leads into failing the if case